### PR TITLE
HubClient: retry transient Hub tree-listing failures (429/5xx)

### DIFF
--- a/Sources/CoreAIKitCore/HubClient.swift
+++ b/Sources/CoreAIKitCore/HubClient.swift
@@ -32,9 +32,28 @@ struct HubClient: Sendable {
         else {
             throw CoreAIKitError.variantNotFound(repo: repo, path: path, revision: revision)
         }
-        let (data, resp) = try await URLSession.shared.data(from: api)
-        guard (resp as? HTTPURLResponse)?.statusCode == 200 else {
-            throw CoreAIKitError.variantNotFound(repo: repo, path: path, revision: revision)
+        // The Hub API sheds load with transient 429s ("maximum queue size reached") and
+        // occasional 5xx; retry those with backoff — only a firm 4xx means the subtree
+        // really isn't published.
+        var data = Data()
+        var status = 0
+        for attempt in 0..<5 {
+            if attempt > 0 {
+                try await Task.sleep(nanoseconds: UInt64(1 << attempt) * 1_000_000_000)
+            }
+            try Task.checkCancellation()
+            let (d, resp) = try await URLSession.shared.data(from: api)
+            status = (resp as? HTTPURLResponse)?.statusCode ?? 0
+            if status == 200 {
+                data = d
+                break
+            }
+            if (400..<500).contains(status), status != 429 {
+                throw CoreAIKitError.variantNotFound(repo: repo, path: path, revision: revision)
+            }
+        }
+        guard status == 200 else {
+            throw CoreAIKitError.httpError(statusCode: status, file: api.absoluteString)
         }
 
         struct TreeEntry: Decodable {


### PR DESCRIPTION
## Problem

`HubClient.listFiles` treats any non-200 response from the Hub tree API as `variantNotFound`, surfacing:

> No '<path>' variant in <repo>@<rev> — this model may not be published for this platform.

…even when the subtree exists. In practice the Hub sheds load with transient `429 {"error":"maximum queue size reached"}` (and occasional 5xx). Multi-bundle models list several subtrees (OCR resolves `vision`/`decoder`/`assets`/`tokenizer`) and those calls race, so a single 429 aborts the whole download with a misleading "not published" message.

Reproduced with `mlboydaisuke/Unlimited-OCR-CoreAI` via `Examples/ReadDoc`: hitting the tree API for the four subtrees returns 429 on some of them, and the run fails even though every subtree is present on `main`.

The large-file download path already retries 6×; only the tree-listing step did not.

## Fix

Retry the tree listing up to 5× with exponential backoff (2/4/8/16 s) on 429/5xx. A firm 4xx (e.g. 404) still means the subtree really isn't published, so it keeps `variantNotFound`. Exhausting retries throws `httpError(statusCode:)` with the real status instead of the misleading message.

One file, `Sources/CoreAIKitCore/HubClient.swift` (+22/-3). No API or behavior change on the success path.

## Verification

`swift run readdoc-cli --model unlimited-ocr --image sample.png` now completes (exit 0) through transient 429s and prints the document markdown.

https://claude.ai/code/session_01HyaY1ZCanqUvYbWVD4Rc53
