### PR TITLE
PocketTTS: throw instead of trapping on two header trust points, namespace the helpers

### DIFF
--- a/Sources/CoreAIKit/PocketTTS/PocketTTS.swift
+++ b/Sources/CoreAIKit/PocketTTS/PocketTTS.swift
@@ -19,6 +19,8 @@ import CoreAI
 import CoreAIKitVision
 import Foundation
 
+private typealias ND = PocketTTSND
+
 public struct PocketTTSPaths: Sendable {
     /// Graph precision of the flow-LM and flow decoder. The Mimi decoder is fp32 at either
     /// setting: twelve state tensors feeding back at 12.5 Hz is exactly where fp16 error
@@ -120,7 +122,7 @@ public final class PocketTTS: @unchecked Sendable {
         where !FileManager.default.fileExists(atPath: u.path) {
             throw PocketTTSError.message("missing asset \(u.lastPathComponent)")
         }
-        let t0 = nowNanos()
+        let t0 = ND.nowNanos()
         lm = try await PocketTTSAsset(url: paths.flowLM, unit: computeUnits)
         flow = try await PocketTTSAsset(url: paths.flowDecoder, unit: computeUnits)
         mimiAsset = try await PocketTTSAsset(url: paths.mimi, unit: computeUnits)
@@ -136,12 +138,12 @@ public final class PocketTTS: @unchecked Sendable {
             .filter { $0.hasSuffix(".safetensors") }
             .map { String($0.dropLast(".safetensors".count)) }
             .sorted()
-        loadSeconds = Double(nowNanos() - t0) / 1e9
+        loadSeconds = Double(ND.nowNanos() - t0) / 1e9
     }
 
     /// Graph-dtype NDArray from float32 host values.
     @inline(__always) private func gd(_ v: [Float], _ shape: [Int]) -> NDArray {
-        half ? ndHalf(v, shape) : nd(v, shape)
+        half ? ND.ndHalf(v, shape) : ND.nd(v, shape)
     }
 
     /// The 12 Mimi streaming-state buffers, host-owned for the lifetime of one run. The
@@ -188,12 +190,12 @@ public final class PocketTTS: @unchecked Sendable {
         states.insert(&state.c3, for: "c3"); states.insert(&state.c5, for: "c5")
         states.insert(&state.c6, for: "c6"); states.insert(&state.c8, for: "c8")
         states.insert(&state.c9, for: "c9"); states.insert(&state.c11, for: "c11")
-        let te = nowNanos()
+        let te = ND.nowNanos()
         var out = try await fMimi.run(inputs: ["latent": latent], states: states)
-        engineNanos &+= nowNanos() &- te
-        let tf = nowNanos()
-        let pcm = try take(&out, "pcm")
-        flattenNanos &+= nowNanos() &- tf
+        engineNanos &+= ND.nowNanos() &- te
+        let tf = ND.nowNanos()
+        let pcm = try ND.take(&out, "pcm")
+        flattenNanos &+= ND.nowNanos() &- tf
         return pcm
     }
 
@@ -240,7 +242,7 @@ public final class PocketTTS: @unchecked Sendable {
         chunks = []
 
         let chunkTexts = try chunker.chunk(text, voicePos: voiceState.positions)
-        let t0 = nowNanos()
+        let t0 = ND.nowNanos()
 
         for chunkText in chunkTexts {
             var cs = PocketTTSChunkStat()
@@ -257,14 +259,14 @@ public final class PocketTTS: @unchecked Sendable {
             let maxGenLen = PocketTTSModel.maxGenLen(tokens: tokens.count)
             precondition(voiceState.positions + tokens.count + maxGenLen <= PocketTTSModel.sMax,
                          "chunker invariant violated: \(voiceState.positions)+\(tokens.count)+\(maxGenLen) > \(PocketTTSModel.sMax)")
-            let tl = nowNanos()
+            let tl = ND.nowNanos()
             let textEmb = weights.embed(tokens)
-            lutN &+= nowNanos() &- tl
+            lutN &+= ND.nowNanos() &- tl
 
             // Fresh KV per chunk, re-seeded from the voice — upstream deep-copies it per
             // chunk, so a chunk never sees the previous chunk's text.
-            var kCache = makeState(voiceState.kSeed, shape: [6, 1, 16, PocketTTSModel.sMax, 64], half: half)
-            var vCache = makeState(voiceState.vSeed, shape: [6, 1, 16, PocketTTSModel.sMax, 64], half: half)
+            var kCache = ND.makeState(voiceState.kSeed, shape: [6, 1, 16, PocketTTSModel.sMax, 64], half: half)
+            var vCache = ND.makeState(voiceState.vSeed, shape: [6, 1, 16, PocketTTSModel.sMax, 64], half: half)
             var pos = Int32(voiceState.positions)
 
             // Windowed prefill over the static T_PRE=16 graph, carrying `pos` across windows.
@@ -273,18 +275,18 @@ public final class PocketTTS: @unchecked Sendable {
             var w = 0
             while w < tokens.count {
                 let width = min(PocketTTSModel.tPre, tokens.count - w)
-                let tm = nowNanos()
+                let tm = ND.nowNanos()
                 var win = [Float](repeating: 0, count: PocketTTSModel.tPre * PocketTTSModel.dModel)
                 for j in 0..<(width * PocketTTSModel.dModel) { win[j] = textEmb[w * PocketTTSModel.dModel + j] }
                 let winND = gd(win, [1, PocketTTSModel.tPre, PocketTTSModel.dModel])
-                let posND = nd([pos], [1])
-                marshN &+= nowNanos() &- tm
+                let posND = ND.nd([pos], [1])
+                marshN &+= ND.nowNanos() &- tm
                 var states = InferenceFunction.MutableViews()
                 states.insert(&kCache, for: "k_cache")
                 states.insert(&vCache, for: "v_cache")
-                let ta = nowNanos()
+                let ta = ND.nowNanos()
                 var out = try await fPrefill.run(inputs: ["text_emb": winND, "pos": posND], states: states)
-                preN &+= nowNanos() &- ta
+                preN &+= ND.nowNanos() &- ta
                 engineCalls += 1
                 _ = out.remove("cond")   // upstream discards the prefill latent too
                 pos += Int32(width)
@@ -306,47 +308,47 @@ public final class PocketTTS: @unchecked Sendable {
                 precondition(Int(pos) + i < PocketTTSModel.sMax,
                              "AR write position \(Int(pos) + i) reached S_MAX=\(PocketTTSModel.sMax)")
 
-                let tm = nowNanos()
+                let tm = ND.nowNanos()
                 let latND = gd(latent, [1, 1, PocketTTSModel.ldim])
                 let bosND = gd([isBOS], [1])
-                let posND = nd([pos + Int32(i)], [1])
-                marshN &+= nowNanos() &- tm
+                let posND = ND.nd([pos + Int32(i)], [1])
+                marshN &+= ND.nowNanos() &- tm
                 var states = InferenceFunction.MutableViews()
                 states.insert(&kCache, for: "k_cache")
                 states.insert(&vCache, for: "v_cache")
-                let ta = nowNanos()
+                let ta = ND.nowNanos()
                 var out = try await fStep.run(
                     inputs: ["latent_in": latND, "is_bos": bosND, "pos": posND], states: states)
-                stepN &+= nowNanos() &- ta
+                stepN &+= ND.nowNanos() &- ta
                 engineCalls += 1
                 isBOS = 0
                 guard let condND = out.remove("cond")?.ndArray else {
                     throw PocketTTSError.message("step: missing 'cond'")
                 }
-                var tf = nowNanos()
-                let eos = try take(&out, "eos_logit")[0]
-                flatN &+= nowNanos() &- tf
+                var tf = ND.nowNanos()
+                let eos = try ND.take(&out, "eos_logit")[0]
+                flatN &+= ND.nowNanos() &- tf
                 if eos > PocketTTSModel.eosThreshold, eosStep == nil { eosStep = i }
 
                 // `cond` goes straight from the step graph's output into the flow decoder's
                 // input — same dtype, no host round-trip.
-                let tn = nowNanos()
+                let tn = ND.nowNanos()
                 let nsND = gd(noise.nextNoise(count: PocketTTSModel.ldim), [1, PocketTTSModel.ldim])
-                marshN &+= nowNanos() &- tn
-                let tb = nowNanos()
+                marshN &+= ND.nowNanos() &- tn
+                let tb = ND.nowNanos()
                 var fout = try await fFlow.run(inputs: ["cond": condND, "noise": nsND])
-                flowN &+= nowNanos() &- tb
+                flowN &+= ND.nowNanos() &- tb
                 engineCalls += 1
-                tf = nowNanos()
-                latent = try take(&fout, "latent")
-                flatN &+= nowNanos() &- tf
+                tf = ND.nowNanos()
+                latent = try ND.take(&fout, "latent")
+                flatN &+= ND.nowNanos() &- tf
 
                 // The latent produced on the breaking step is DISCARDED.
                 if let e = eosStep, i >= e + framesAfterEOS { i += 1; break }
 
-                let tw = nowNanos()
-                let latMimiND = nd(latent, [1, PocketTTSModel.ldim])
-                marshN &+= nowNanos() &- tw
+                let tw = ND.nowNanos()
+                let latMimiND = ND.nd(latent, [1, PocketTTSModel.ldim])
+                marshN &+= ND.nowNanos() &- tw
                 let pcm = try await mimiFrame(latent: latMimiND, state: &mimiState,
                                               engineNanos: &mimiN, flattenNanos: &flatN)
                 engineCalls += 1
@@ -362,11 +364,11 @@ public final class PocketTTS: @unchecked Sendable {
             chunks.append(cs)
 
             if applyGain { _ = PocketTTSVoiceGain.apply(&chunkAudio, voice: voice) }
-            if firstChunk < 0 { firstChunk = Double(nowNanos() - t0) / 1e9 }
+            if firstChunk < 0 { firstChunk = Double(ND.nowNanos() - t0) / 1e9 }
             try await emit(chunkAudio)
         }
 
-        let total = Double(nowNanos() - t0) / 1e9
+        let total = Double(ND.nowNanos() - t0) / 1e9
         profile = ["wall": total * 1000, "prefill": Double(preN) / 1e6, "step": Double(stepN) / 1e6,
                    "flow": Double(flowN) / 1e6, "mimi": Double(mimiN) / 1e6,
                    "lut": Double(lutN) / 1e6, "marshal": Double(marshN) / 1e6,

--- a/Sources/CoreAIKit/PocketTTS/PocketTTSChunker.swift
+++ b/Sources/CoreAIKit/PocketTTS/PocketTTSChunker.swift
@@ -131,10 +131,23 @@ struct PocketTTSChunker {
     /// additionally capped by upstream's own MAX_TOKEN_PER_CHUNK. For the shipped voices
     /// (126–162 conditioning positions) the upstream 50 cap is the binding one; the
     /// derivation is here so a longer voice can never silently break the budget.
-    static func tokenBudget(voicePos: Int, sMax: Int = PocketTTSModel.sMax) -> Int {
+    ///
+    /// Throws rather than clamping when the voice leaves no room at all: flooring at one
+    /// token would hand the pipeline a budget the invariant does not support, and the
+    /// overflow `precondition` in the AR loop would then trap on chunker output that this
+    /// function promised was safe. Unreachable for the shipped voices, reachable for a
+    /// custom embedding dropped into `voicesDir`, which the API invites.
+    static func tokenBudget(voicePos: Int, sMax: Int = PocketTTSModel.sMax) throws -> Int {
         var n = PocketTTSModel.maxTokensPerChunk
         while n > 0, voicePos + n + PocketTTSModel.maxGenLen(tokens: n) > sMax { n -= 1 }
-        return max(n, 1)
+        guard n > 0 else {
+            let onePos = 1 + PocketTTSModel.maxGenLen(tokens: 1)
+            throw PocketTTSError.message(
+                "voice conditioning is too long: \(voicePos) positions leave no room for a "
+                + "single text token within S_MAX \(sMax), which needs \(onePos) more. "
+                + "The limit is \(sMax - onePos) positions; the shipped voices use 126-162.")
+        }
+        return n
     }
 
     /// The production chunker: upstream's split, then hard enforcement of the budget.
@@ -142,7 +155,7 @@ struct PocketTTSChunker {
     /// what the pipeline actually prefills, so the runtime overflow assert can never fire
     /// on chunker output.
     func chunk(_ rawText: String, voicePos: Int) throws -> [String] {
-        let budget = Self.tokenBudget(voicePos: voicePos)
+        let budget = try Self.tokenBudget(voicePos: voicePos)
         var out: [String] = []
         for c in try upstreamSplit(rawText, maxTokens: budget) {
             if sp.encode(c).count <= budget {

--- a/Sources/CoreAIKit/PocketTTS/PocketTTSGraph.swift
+++ b/Sources/CoreAIKit/PocketTTS/PocketTTSGraph.swift
@@ -12,12 +12,13 @@ import CoreAI
 import CoreAIKitVision
 import Foundation
 
+/// Short local name for the marshalling namespace defined at the bottom of this file.
+private typealias ND = PocketTTSND
+
 enum PocketTTSError: Error, CustomStringConvertible {
     case message(String)
     var description: String { switch self { case .message(let m): return m } }
 }
-
-@inline(__always) func nowNanos() -> UInt64 { clock_gettime_nsec_np(CLOCK_UPTIME_RAW) }
 
 /// One loaded `.aimodel` bundle, holding the `AIModel` so `function(_:)` can vend several
 /// entry points from it. The flow-LM asset is **multifunction** — `prefill` and `step` over
@@ -34,9 +35,9 @@ final class PocketTTSAsset {
     init(url: URL, unit: GraphModel.ComputeUnits) async throws {
         self.url = url
         self.unit = unit
-        let t0 = nowNanos()
+        let t0 = ND.nowNanos()
         self.model = try await AIModel(contentsOf: url, options: unit.specializationOptions)
-        self.loadSeconds = Double(nowNanos() - t0) / 1e9
+        self.loadSeconds = Double(ND.nowNanos() - t0) / 1e9
     }
 
     var functionNames: [String] { model.functionNames }
@@ -51,88 +52,102 @@ final class PocketTTSAsset {
 
 // MARK: - NDArray helpers
 
-/// Build a float32 NDArray from a Swift array.
-func nd(_ values: [Float], _ shape: [Int]) -> NDArray {
-    NDArray(scalars: values, shape: shape)
-}
-
-func nd(_ values: [Int32], _ shape: [Int]) -> NDArray {
-    NDArray(scalars: values, shape: shape)
-}
-
-/// Build a float16 NDArray by narrowing float32 values. Used when the flow-LM / flow
-/// decoder assets are the fp16 export — the graph's declared input dtype must be matched
-/// exactly or the runtime rejects the call.
-func ndHalf(_ values: [Float], _ shape: [Int]) -> NDArray {
-    NDArray(scalars: values.map { Float16($0) }, shape: shape)
-}
-
-/// Allocate an NDArray of the given scalar type and fill it from float32 source data.
+/// Marshalling helpers for this port, namespaced rather than left at module scope.
 ///
-/// This is how the KV state gets created: a *state* is a buffer the runtime mutates in
-/// place across calls; the host owns it, hands the runtime a mutable view each call, and
-/// never reads it back. Zero-initialised, not NaN — a masked SDPA still multiplies V by a
-/// zero weight and `0 * NaN` is `NaN` (NOTES.md §6, blocker iii-b).
-func makeState(_ values: [Float], shape: [Int], half: Bool) -> NDArray {
-    var a = NDArray(shape: shape, scalarType: half ? .float16 : .float32)
-    if half {
-        var mv = a.mutableView(as: Float16.self)
-        mv.withUnsafeMutablePointer { p, _, _ in
-            for i in 0..<values.count { p[i] = Float16(values[i]) }
-        }
-    } else {
-        var mv = a.mutableView(as: Float.self)
-        mv.withUnsafeMutablePointer { p, _, _ in
-            for i in 0..<values.count { p[i] = values[i] }
-        }
+/// `nd`, `flat` and `take` are the names the *next* port will want too, and everything in
+/// `CoreAIKit` shares one module namespace, so at file scope the first port to land simply
+/// takes them. A caseless `enum` is Swift's idiom for a namespace: it has no cases, so it
+/// cannot be instantiated, and it exists only to qualify the members inside it. Consumers
+/// shorten it back with a file-private `typealias ND = PocketTTSND`, which keeps call sites
+/// as readable as they were while leaving the bare names free for everyone else.
+enum PocketTTSND {
+    @inline(__always) static func nowNanos() -> UInt64 {
+        clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
     }
-    return a
-}
 
-/// Flatten any float output to `[Float]`, row-major, widening fp16.
-func flat(_ array: NDArray) -> [Float] {
-    switch array.scalarType {
-    case .float16: return flatten(array, as: Float16.self)
-    case .float32: return flatten(array, as: Float.self)
-    default: preconditionFailure("unsupported output scalar type \(array.scalarType)")
+    /// Build a float32 NDArray from a Swift array.
+    static func nd(_ values: [Float], _ shape: [Int]) -> NDArray {
+        NDArray(scalars: values, shape: shape)
     }
-}
 
-private func flatten<T: BinaryFloatingPoint & BitwiseCopyable>(_ a: NDArray, as _: T.Type) -> [Float] {
-    let total = a.shape.reduce(1, *)
-    var out = [Float](repeating: 0, count: total)
-    a.view(as: T.self).withUnsafePointer { p, shp, strides in
-        var expected = 1
-        var contiguous = true
-        for d in stride(from: shp.count - 1, through: 0, by: -1) {
-            if strides[d] != expected { contiguous = false; break }
-            expected *= shp[d]
-        }
-        if contiguous {
-            for i in 0..<total { out[i] = Float(p[i]) }
-            return
-        }
-        var idx = [Int](repeating: 0, count: shp.count)
-        for i in 0..<total {
-            var off = 0
-            for d in 0..<shp.count { off += idx[d] * strides[d] }
-            out[i] = Float(p[off])
-            var d = shp.count - 1
-            while d >= 0 {
-                idx[d] += 1
-                if idx[d] < shp[d] { break }
-                idx[d] = 0
-                d -= 1
+    static func nd(_ values: [Int32], _ shape: [Int]) -> NDArray {
+        NDArray(scalars: values, shape: shape)
+    }
+
+    /// Build a float16 NDArray by narrowing float32 values. Used when the flow-LM / flow
+    /// decoder assets are the fp16 export — the graph's declared input dtype must be matched
+    /// exactly or the runtime rejects the call.
+    static func ndHalf(_ values: [Float], _ shape: [Int]) -> NDArray {
+        NDArray(scalars: values.map { Float16($0) }, shape: shape)
+    }
+
+    /// Allocate an NDArray of the given scalar type and fill it from float32 source data.
+    ///
+    /// This is how the KV state gets created: a *state* is a buffer the runtime mutates in
+    /// place across calls; the host owns it, hands the runtime a mutable view each call, and
+    /// never reads it back. Zero-initialised, not NaN — a masked SDPA still multiplies V by a
+    /// zero weight and `0 * NaN` is `NaN` (NOTES.md §6, blocker iii-b).
+    static func makeState(_ values: [Float], shape: [Int], half: Bool) -> NDArray {
+        var a = NDArray(shape: shape, scalarType: half ? .float16 : .float32)
+        if half {
+            var mv = a.mutableView(as: Float16.self)
+            mv.withUnsafeMutablePointer { p, _, _ in
+                for i in 0..<values.count { p[i] = Float16(values[i]) }
+            }
+        } else {
+            var mv = a.mutableView(as: Float.self)
+            mv.withUnsafeMutablePointer { p, _, _ in
+                for i in 0..<values.count { p[i] = values[i] }
             }
         }
+        return a
     }
-    return out
-}
 
-/// Pull one named output as `[Float]`, consuming it out of the `Outputs` bag.
-func take(_ outputs: inout InferenceFunction.Outputs, _ name: String) throws -> [Float] {
-    guard let v = outputs.remove(name)?.ndArray else {
-        throw PocketTTSError.message("missing output '\(name)'")
+    /// Flatten any float output to `[Float]`, row-major, widening fp16.
+    static func flat(_ array: NDArray) -> [Float] {
+        switch array.scalarType {
+        case .float16: return flatten(array, as: Float16.self)
+        case .float32: return flatten(array, as: Float.self)
+        default: preconditionFailure("unsupported output scalar type \(array.scalarType)")
+        }
     }
-    return flat(v)
+
+    private static func flatten<T: BinaryFloatingPoint & BitwiseCopyable>(_ a: NDArray, as _: T.Type) -> [Float] {
+        let total = a.shape.reduce(1, *)
+        var out = [Float](repeating: 0, count: total)
+        a.view(as: T.self).withUnsafePointer { p, shp, strides in
+            var expected = 1
+            var contiguous = true
+            for d in stride(from: shp.count - 1, through: 0, by: -1) {
+                if strides[d] != expected { contiguous = false; break }
+                expected *= shp[d]
+            }
+            if contiguous {
+                for i in 0..<total { out[i] = Float(p[i]) }
+                return
+            }
+            var idx = [Int](repeating: 0, count: shp.count)
+            for i in 0..<total {
+                var off = 0
+                for d in 0..<shp.count { off += idx[d] * strides[d] }
+                out[i] = Float(p[off])
+                var d = shp.count - 1
+                while d >= 0 {
+                    idx[d] += 1
+                    if idx[d] < shp[d] { break }
+                    idx[d] = 0
+                    d -= 1
+                }
+            }
+        }
+        return out
+    }
+
+    /// Pull one named output as `[Float]`, consuming it out of the `Outputs` bag.
+    static func take(_ outputs: inout InferenceFunction.Outputs, _ name: String) throws -> [Float] {
+        guard let v = outputs.remove(name)?.ndArray else {
+            throw PocketTTSError.message("missing output '\(name)'")
+        }
+        return flat(v)
+    }
 }

--- a/Sources/CoreAIKit/PocketTTS/PocketTTSSafetensors.swift
+++ b/Sources/CoreAIKit/PocketTTS/PocketTTSSafetensors.swift
@@ -37,6 +37,17 @@ struct PocketTTSSafeTensors {
                   let offs = t["data_offsets"] as? [Int], offs.count == 2 else {
                 throw PocketTTSError.message("\(url.lastPathComponent): malformed entry '\(name)'")
             }
+            // `data_offsets` is file-controlled, and these files arrive through `HubClient`,
+            // so a half-finished download is the case that actually happens. Both failure
+            // shapes are traps rather than throws: `a..<b` traps when reversed, and the
+            // `subdata` calls below trap when the range outruns the buffer. Validating here
+            // means every consumer reads a range already proven to lie inside the payload.
+            let payload = raw.count - hEnd
+            guard offs[0] >= 0, offs[0] <= offs[1], offs[1] <= payload else {
+                throw PocketTTSError.message(
+                    "\(url.lastPathComponent): entry '\(name)' claims bytes "
+                    + "\(offs[0])..<\(offs[1]) of a \(payload)-byte payload")
+            }
             out[name] = Entry(dtype: dtype, shape: shape, byteRange: offs[0]..<offs[1])
         }
         self.entries = out


### PR DESCRIPTION
Notes 2, 3 and 4 from your review on #6. The gain seam is not here: that one is yours to push, and my reasoning on why the 96 stitch points survive it either way is in the [thread](https://github.com/john-rocky/coreai-kit/pull/6#issuecomment-5300538925).

Both of the throwing fixes were bugs in the reference port as well, not just in what I carried across. They are fixed there in the same shape ([`pocket-tts-swift@6d7b5df`](https://github.com/RahulRachuri/pocket-tts-swift/commit/6d7b5df)), so the two trees do not drift.

### `PocketTTSSafetensors`: validate `data_offsets` at parse time

The header length was bounds-checked and the offsets were then trusted. Reversed offsets trap where the `Range` is constructed, and offsets past the end trap inside `subdata`, so a half-finished `HubClient` download took the host app down instead of surfacing a `PocketTTSError`. One `0 <= lo <= hi <= payload` check where the entry is built covers both, and it means the two reads below are handed a range already proven to lie inside the buffer rather than each needing its own guard.

### `PocketTTSChunker.tokenBudget`: report the voice that does not fit

`max(n, 1)` clamped to a budget the invariant does not support, so the chunker handed the AR loop a chunk that then tripped the overflow `precondition` the chunker exists to make unreachable. It now throws and names the limit, which works out to **481 conditioning positions** against S_MAX 512, since one token needs `1 + maxGenLen(1) = 31`. That is close to the 490 you estimated. Unreachable for the eight shipped voices at 126-162, reachable for a custom embedding in `voicesDir`.

### The six helpers move under `PocketTTSND`

A caseless enum, with each consumer taking a file-private `typealias ND = PocketTTSND`, so the 41 call sites still read `ND.take(&outputs, "pcm")` and the bare names go back to being available. Calls inside the enum stay unqualified. You were right that `take` is the one that would have bitten: it is the first name the next port reaches for.

### Verification

`swift build` is clean. I could not run `swift test` locally, and it is worth flagging because it is nothing to do with this branch: the test bundle fails to `dlopen` on `FoundationModels.Attachment.init(_:orientation:)`, called from `Sources/CoreAIOps/CoreAI+Image.swift:199`. The Xcode-beta 27.0 SDK stub declares that initialiser and the FoundationModels shipped in macOS 27.0 build 26A5406e does not export it, so linking resolves it and loading does not. Unmodified `origin/main` fails identically on this machine, so CI is the real check here. If you are on the same OS build you will see it too, and it is a runtime concern for that image path rather than a test-only one.
