### PR TITLE
Gemma 4 E2B: wire the catalog to the b2 (loadable) decode bundle

### DIFF
--- a/Sources/CoreAIKit/Gemma/KitGemmaModel.swift
+++ b/Sources/CoreAIKit/Gemma/KitGemmaModel.swift
@@ -37,9 +37,9 @@ public struct GemmaModelID: Sendable, Hashable {
     /// on-device GPU specializer (`LLVM ERROR: Failed to allocate mmap'd buffer`). macOS
     /// JIT-specializes the plain `…_tbl` bundle fine (there is no Mac AOT artifact).
     #if os(iOS)
-    static let gemma4E2BDecoderPath = "gpu-pipelined/gemma4_e2b_qat_decode_int4lin_tbl_aotc_h18p"
+    static let gemma4E2BDecoderPath = "gpu-pipelined-b2/gemma4_e2b_qat_decode_int4lin_tbl_aotc_h18p"
     #else
-    static let gemma4E2BDecoderPath = "gpu-pipelined/gemma4_e2b_qat_decode_int4lin_tbl"
+    static let gemma4E2BDecoderPath = "gpu-pipelined-b2/gemma4_e2b_qat_decode_int4lin_tbl"
     #endif
 
     /// Gemma 4 E2B, official-QAT int4 (license: gemma). The shippable on-device size — a

--- a/Sources/CoreAIKitCore/BuiltinPins.swift
+++ b/Sources/CoreAIKitCore/BuiltinPins.swift
@@ -17,7 +17,7 @@ enum BuiltinPins {
         "gemma-3-4b-it": "89a7c7a7a4e0c870f50f73d587f2bc8fad6acc28",
         "gemma-4-12b": "feff92c54c9fbadd4721da0e617214212a498e5a",
         "gemma-4-31b": "c80f188d8e8ad8f8b0aee6acfda8b378294e202d",
-        "gemma-4-e2b": "92ab927568a37fdd3c8b4d46f3c4685804f08e46",
+        "gemma-4-e2b": "d669ab2b44c691e35e2b795f0535c0e1937b8390",
         "gemma-4-e4b": "480fc1d9bbbd15d7e81e4d0a68d5efdee6eb4c2b",
         "glm-4.7-flash": "e40bf6f8aa7fdc55d7037d45fd274f19382baaff",
         "glm-ocr": "cb88cd8e5e3a730d5be1f4b56b319621c25fcca7",

--- a/Sources/CoreAIKitCore/ModelCatalog.swift
+++ b/Sources/CoreAIKitCore/ModelCatalog.swift
@@ -427,9 +427,9 @@ public struct ModelCatalog: Sendable, Codable {
                 repo: "mlboydaisuke/gemma-4-E2B-CoreAI", kind: .chat,
                 variants: [
                     "macos": .init(
-                        path: "gpu-pipelined/gemma4_e2b_qat_decode_int4lin_tbl", sizeMB: 4929),
+                        path: "gpu-pipelined-b2/gemma4_e2b_qat_decode_int4lin_tbl", sizeMB: 4929),
                     "ios": .init(
-                        path: "gpu-pipelined/gemma4_e2b_qat_decode_int4lin_tbl_aotc_h18p",
+                        path: "gpu-pipelined-b2/gemma4_e2b_qat_decode_int4lin_tbl_aotc_h18p",
                         sizeMB: 4931),
                 ],
                 engine: "pipelined"),

--- a/Tests/CoreAIKitTests/GemmaModelIDTests.swift
+++ b/Tests/CoreAIKitTests/GemmaModelIDTests.swift
@@ -13,11 +13,11 @@ final class GemmaModelIDTests: XCTestCase {
         #if os(iOS)
         XCTAssertEqual(
             GemmaModelID.gemma4E2B.decoder.path,
-            "gpu-pipelined/gemma4_e2b_qat_decode_int4lin_tbl_aotc_h18p")
+            "gpu-pipelined-b2/gemma4_e2b_qat_decode_int4lin_tbl_aotc_h18p")
         #else
         XCTAssertEqual(
             GemmaModelID.gemma4E2B.decoder.path,
-            "gpu-pipelined/gemma4_e2b_qat_decode_int4lin_tbl")
+            "gpu-pipelined-b2/gemma4_e2b_qat_decode_int4lin_tbl")
         #endif
     }
 
@@ -34,9 +34,9 @@ final class GemmaModelIDTests: XCTestCase {
         let entry = ModelCatalog.builtin.entry(id: "gemma-4-e2b")
         XCTAssertEqual(
             entry?.variants["macos"]?.path,
-            "gpu-pipelined/gemma4_e2b_qat_decode_int4lin_tbl")
+            "gpu-pipelined-b2/gemma4_e2b_qat_decode_int4lin_tbl")
         XCTAssertEqual(
             entry?.variants["ios"]?.path,
-            "gpu-pipelined/gemma4_e2b_qat_decode_int4lin_tbl_aotc_h18p")
+            "gpu-pipelined-b2/gemma4_e2b_qat_decode_int4lin_tbl_aotc_h18p")
     }
 }

--- a/catalog.json
+++ b/catalog.json
@@ -399,15 +399,15 @@
       "id": "gemma-4-e2b",
       "name": "Gemma 4 E2B",
       "repo": "mlboydaisuke/gemma-4-E2B-CoreAI",
-      "revision": "92ab927568a37fdd3c8b4d46f3c4685804f08e46",
+      "revision": "d669ab2b44c691e35e2b795f0535c0e1937b8390",
       "kind": "chat",
       "variants": {
         "macos": {
-          "path": "gpu-pipelined/gemma4_e2b_qat_decode_int4lin_tbl",
+          "path": "gpu-pipelined-b2/gemma4_e2b_qat_decode_int4lin_tbl",
           "sizeMB": 4929
         },
         "ios": {
-          "path": "gpu-pipelined/gemma4_e2b_qat_decode_int4lin_tbl_aotc_h18p",
+          "path": "gpu-pipelined-b2/gemma4_e2b_qat_decode_int4lin_tbl_aotc_h18p",
           "sizeMB": 4931
         }
       },


### PR DESCRIPTION
## What

Gemma 4 E2B's decode bundle pointed at `gpu-pipelined/gemma4_e2b_qat_decode_int4lin_tbl` — a 0.4.0-era bundle with no producer stamp that no longer loads on recent Core AI runtimes (the same IR-040 signature as `qwen3.5-0.8B` `perchan_sym`, reproduced at load on macOS 27 `26A5416b`). The re-exported fix has sat unused in `gpu-pipelined-b2/` since July.

This points the decoder (`KitGemmaModel.gemma4E2BDecoderPath`, both platforms) and the catalog variants at `gpu-pipelined-b2/`, and bumps the E2B pin `92ab927 → d669ab2` (the current tip, which contains the b2 bundle).

## Why it's safe

- The PLE tables (`ios-frontend/gemma4_qat_gather_raw`) are **byte-identical** across the pin bump, and every intervening commit is card/metadata — so only the decoder bytes change.
- The published b2 Mac decode (`coreai-core 1.0.0b2`) **loads on 26A5416b** (bare `cpu_only` load, 7.0s, functions `[main]`), downloaded at the new pin.
- `catalog.json`, the builtin literal, and the generated pins stay in sync — `ModelCatalogTests` + `BuiltinPinsTests` green, `gen-builtin-pins.py --check` green.

## Follow-up (not in this PR)

- The iOS `aotc_h18p` variant now points at the b2 compiled artifact, but a `.aimodelc` cannot be loaded on a Mac — it needs an **on-device smoke** (SiriAsk / PipelinedBench) before a release ships.
- E4B / 12B / 31B still point at 0.4.0-era decode bundles with **no b2 twin yet** — those need a re-export, not a re-point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mbT3to76Yy5iu1feZwCki
